### PR TITLE
Multiplayer + newline fix

### DIFF
--- a/src/main/java/org/terasology/books/logic/BookComponent.java
+++ b/src/main/java/org/terasology/books/logic/BookComponent.java
@@ -18,6 +18,8 @@ package org.terasology.books.logic;
 
 import com.google.common.collect.Lists;
 import org.terasology.entitySystem.Component;
+import org.terasology.network.FieldReplicateType;
+import org.terasology.network.Replicate;
 import org.terasology.rendering.nui.Color;
 
 import java.util.ArrayList;
@@ -33,10 +35,13 @@ public class BookComponent implements Component {
     public Color tint = Color.WHITE;
     public BookType type = BookType.Written;
 
+    @Replicate
     public boolean readOnly;
+    @Replicate
     public String title;
 
     //The list of page's length must be even or thing will explode.
+    @Replicate(FieldReplicateType.OWNER_TO_SERVER)
     public List<String> pages = new ArrayList<>(Lists.newArrayList("", ""));
 }
 

--- a/src/main/java/org/terasology/books/rendering/nui/layers/BookScreen.java
+++ b/src/main/java/org/terasology/books/rendering/nui/layers/BookScreen.java
@@ -167,7 +167,7 @@ public class BookScreen extends BaseInteractionScreen {
     }
 
     private static ParagraphData createTextParagraph(String text) {
-        return HTMLLikeParser.parseHTMLLikeParagraph(null, "<c " + "198"/*Color.BLACK.getRepresentation()*/ + ">" + text + "</c>");
+        return HTMLLikeParser.parseHTMLLikeParagraph(null, "<c " + "198"/*Color.BLACK.getRepresentation()*/ + ">" + text.replace("\n", "<l>") + "</c>");
     }
 
     private static RecipeParagraph createRecipeParagraph(String prefabName) {


### PR DESCRIPTION
Multiplayer fix:
Added a `@Replicate` annotation inside the BookComponent so that the text is synched from the OWNER_TO_SERVER.

Newline fix:
https://github.com/MovingBlocks/Terasology/pull/2988 allows creating a newline in a multiline UIText box. Saving text with newlines in a book, however, produces a problem- the HTML renderer (used to display book content) cannot take newlines. Instead of `\n`, it takes `<l>`. So all occurrences of `n` are replaced with `<l>` before the text is parsed into the HTML-like language.