### PR TITLE
Fix RecipeBook not showing recipes error.

### DIFF
--- a/src/main/java/org/terasology/books/RecipeParagraph.java
+++ b/src/main/java/org/terasology/books/RecipeParagraph.java
@@ -42,14 +42,14 @@ public class RecipeParagraph implements ParagraphData, ParagraphRenderable {
     private ItemIcon[] ingredientIcons;
     private ItemIcon resultIcon;
 
-    public RecipeParagraph(List<Block> blockIngredients, List<Prefab> itemIngredients, Block blockResult, Prefab itemResult, int resultCount) {
-        ingredientIcons = new ItemIcon[blockIngredients.size()];
+    public RecipeParagraph(int blockIngredients, List<Block> blockIngredientsList, List<Prefab> itemIngredients, Block blockResult, Prefab itemResult, int resultCount) {
+        ingredientIcons = new ItemIcon[blockIngredients];
         for (int i = 0; i < ingredientIcons.length; i++) {
             ItemIcon itemIcon = new ItemIcon();
-            if (blockIngredients.get(i) != null) {
-                initializeForBlock(itemIcon, blockIngredients.get(i));
+            if (i < blockIngredientsList.size()) {
+                initializeForBlock(itemIcon, blockIngredientsList.get(i));
             } else {
-                initializeForItem(itemIcon, itemIngredients.get(i));
+                initializeForItem(itemIcon, itemIngredients.get(i - blockIngredientsList.size()));
             }
             ingredientIcons[i] = itemIcon;
         }

--- a/src/main/java/org/terasology/books/logic/BookRecipeComponent.java
+++ b/src/main/java/org/terasology/books/logic/BookRecipeComponent.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public class BookRecipeComponent implements Component {
     public int blockIngredients;
-    public List<Block> blockIngredientsList;
+    public List<Block> blockIngredientsList = new ArrayList<>();
     public List<Prefab> itemIngredients = new ArrayList<>();
     public Block blockResult = null;
     public Prefab itemResult;

--- a/src/main/java/org/terasology/books/rendering/nui/layers/BookScreen.java
+++ b/src/main/java/org/terasology/books/rendering/nui/layers/BookScreen.java
@@ -16,9 +16,6 @@
 package org.terasology.books.rendering.nui.layers;
 
 import com.google.common.base.Joiner;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.books.DefaultDocumentData;
@@ -36,7 +33,11 @@ import org.terasology.logic.inventory.InventoryUtils;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
 import org.terasology.rendering.assets.texture.TextureRegion;
-import org.terasology.rendering.nui.*;
+import org.terasology.rendering.nui.BaseInteractionScreen;
+import org.terasology.rendering.nui.Color;
+import org.terasology.rendering.nui.HorizontalAlign;
+import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.WidgetUtil;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.widgets.UIButton;
@@ -48,7 +49,6 @@ import org.terasology.rendering.nui.widgets.browser.data.basic.HTMLLikeParser;
 import org.terasology.rendering.nui.widgets.browser.ui.BrowserWidget;
 import org.terasology.rendering.nui.widgets.browser.ui.style.ParagraphRenderStyle;
 import org.terasology.utilities.Assets;
-import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
 
 import java.util.ArrayList;
@@ -173,7 +173,8 @@ public class BookScreen extends BaseInteractionScreen {
     private static RecipeParagraph createRecipeParagraph(String prefabName) {
         Prefab recipePrefab = prefabManager.getPrefab(prefabName);
         BookRecipeComponent bookRecipeComponent = recipePrefab.getComponent(BookRecipeComponent.class);
-        return new RecipeParagraph(bookRecipeComponent.blockIngredientsList, bookRecipeComponent.itemIngredients, bookRecipeComponent.blockResult, bookRecipeComponent.itemResult, bookRecipeComponent.resultCount);
+        return new RecipeParagraph(bookRecipeComponent.blockIngredients, bookRecipeComponent.blockIngredientsList, bookRecipeComponent.itemIngredients,
+                bookRecipeComponent.blockResult, bookRecipeComponent.itemResult, bookRecipeComponent.resultCount);
     }
 
     static State getState() {


### PR DESCRIPTION
Edited the following classes to fix the "Recipes do not display in RecipeBook" issue:
- `RecipeParagraph.java`
- `BookRecipeComponent.java`
- `Bookscreen.java`

`BookRecipeComponent.java`: Instantiated the List<Block> `blockIngredientsList` to a new ArrayList to prevent a nullpointer exception.

`RecipeParagraph.java`: Included int `blockIngredients` from the `BookRecipeComponent.java` class as a parameter for the constructor to represent the size of the List, rather than using the size of one of the Lists to represent it. Changed the original name of the first List from `blockIngredients` to `blockIngredientsList` to prevent confusion with the new int `blockIngredients`. Changed the if-else condition in the constructor to be more relevant to ArrayLists. Changed the `itemIngredients.get(i)` parameter in the initializeForItem call in the else statement of the constructor to `itemIngredients.get(i - blockIngredientsList.size ())`. This is because it should be attaching the `itemIngredients` ArrayList to the end of the `blockIngredientsList` ArrayList, so it should start at 0 when i > the `blockIngredientsList` ArrayList's size.

`BookScreen.java`: Accounted for the change of the parameters in the constructor call for RecipeParagraph.

Screenshot of the fix in action:
![image](https://user-images.githubusercontent.com/32719081/47692340-a81b3700-dbcb-11e8-94f3-168f8861f115.png)

