### PR TITLE
chore: replace `Core` with `Coreitems`

### DIFF
--- a/assets/prefabs/Recipes/pickaxe.prefab
+++ b/assets/prefabs/Recipes/pickaxe.prefab
@@ -2,10 +2,10 @@
   "BookRecipe": {
     "blockIngredients": 2,
     "itemIngredients": [
-      "core:pickaxe",
-      "core:pickaxe"
+      "CoreItems:pickaxe",
+      "CoreItems:pickaxe"
     ],
-    "itemResult": "core:pickaxe",
+    "itemResult": "CoreItems:pickaxe",
     "resultCount": 1
   }
 }

--- a/module.txt
+++ b/module.txt
@@ -6,7 +6,8 @@
     "description" : "This module introduces books and bookcases",
     "dependencies" : [
         {"id" : "CoreItems", "minVersion" : "1.0.0"},
-        {"id" : "CoreAssets", "minVersion" : "1.0.0"}
+        {"id" : "CoreAssets", "minVersion" : "1.0.0"},
+        {"id" : "Inventory", "minVersion" : "1.1.0"}
     ],
     "isServerSideOnly" : false
 }

--- a/module.txt
+++ b/module.txt
@@ -1,11 +1,11 @@
 {
     "id" : "Books",
-    "version" : "1.0.3-SNAPSHOT",
+    "version" : "1.1.0",
     "author" : "nihal111, bi0hax, Waterpicker",
     "displayName" : "Books and Bookcases",
     "description" : "This module introduces books and bookcases",
     "dependencies" : [
-        {"id" : "Core", "minVersion" : "3.0.0"},
+        {"id" : "CoreItems", "minVersion" : "1.0.0"},
         {"id" : "CoreAssets", "minVersion" : "1.0.0"}
     ],
     "isServerSideOnly" : false


### PR DESCRIPTION
Related to https://github.com/MovingBlocks/Terasology/pull/3922

- replaces references and dependencies on `Core` with `CoreItems` respectively